### PR TITLE
Pass files through if they are already JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var extend = require('util-extend');
 var sort = require('sort-object');
 var through = require('through2');
 var util = require('util');
-var validator = require('validator');
 
 var expand = require('expand-hash');
 var frontmatter = require('front-matter');
@@ -13,13 +12,19 @@ var NAME = 'gulp-markdown-to-json';
 var PluginError = gutil.PluginError;
 var streamingErr = new PluginError(NAME, 'Streaming not supported');
 
+function isJSON(str) {
+  try { JSON.parse(str); }
+  catch (e) { return false; }
+  return true;
+}
+
 function parse( file, flatten ){
   if( file.isNull() ) return;
   if( file.isStream() ) return this.emit('error', streamingErr);
 
   if( file.isBuffer() ){
     var fileContents = file.contents.toString();
-    if (validator.isJSON(fileContents)) return file;
+    if (isJSON(fileContents)) return file;
     var path = file.relative.split('.').shift().replace(/\//g, '.');
     var parsed = frontmatter(fileContents);
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var extend = require('util-extend');
 var sort = require('sort-object');
 var through = require('through2');
 var util = require('util');
+var validator = require('validator');
 
 var expand = require('expand-hash');
 var frontmatter = require('front-matter');
@@ -17,8 +18,10 @@ function parse( file, flatten ){
   if( file.isStream() ) return this.emit('error', streamingErr);
 
   if( file.isBuffer() ){
+    var fileContents = file.contents.toString();
+    if (validator.isJSON(fileContents)) return file;
     var path = file.relative.split('.').shift().replace(/\//g, '.');
-    var parsed = frontmatter(file.contents.toString());
+    var parsed = frontmatter(fileContents);
 
     var body = parsed.body.split(/\n/);
     var markup = marked(parsed.body).split(/\n/);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "marked": "^0.3.0",
     "sort-object": "^0.0.6",
     "through2": "^0.4.0",
-    "util-extend": "^1.0.1"
+    "util-extend": "^1.0.1",
+    "validator": "^3.40.1"
   },
   "devDependencies": {
     "vinyl-fs": "~0.3.5"

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "marked": "^0.3.0",
     "sort-object": "^0.0.6",
     "through2": "^0.4.0",
-    "util-extend": "^1.0.1",
-    "validator": "^3.40.1"
+    "util-extend": "^1.0.1"
   },
   "devDependencies": {
     "vinyl-fs": "~0.3.5"


### PR DESCRIPTION
This is aimed at opening up the workflow a bit so that other filetypes could be collected and combined to the single 'content' JSON file. I added the 'validator' package here because it offers an easy method for checking if a string is JSON, and modified the parse method to return the file if the check is true. 